### PR TITLE
Updates to support import2 loading large sets of historical data.

### DIFF
--- a/src/tools/TextImporter2.java
+++ b/src/tools/TextImporter2.java
@@ -59,7 +59,7 @@ final class TextImporter2 {
 		toScreen = argp.has("--print");
 
 		final long start_time = System.nanoTime();
-		int points = 0;
+		long points = 0;
 		// get a config object
 		TSDB tsdb = null;
 
@@ -89,7 +89,7 @@ final class TextImporter2 {
 		}
 	}
 
-	private static void displayAvgSpeed(final long start_time, final int points) {
+	private static void displayAvgSpeed(final long start_time, final long points) {
 		final double time_delta = (System.nanoTime() - start_time) / 1000000000.0;
 		LOG.info(String.format("Average speed: %d data points in %.3fs (%.1f points/s)",
 				points, time_delta, (points / time_delta)));
@@ -100,12 +100,12 @@ final class TextImporter2 {
 	 * @return number of points imported from file
 	 * @throws IOException
 	 */
-	private static int importFile(final TSDB tsdb, final String path) throws IOException {
+	private static long importFile(final TSDB tsdb, final String path) throws IOException {
 
 		final BufferedReader in = open(path);
 		String line = null;
 
-		int points = 0;
+		long points = 0;
 
 		final long start_time = System.nanoTime();
 		

--- a/src/tools/TextImporter2.java
+++ b/src/tools/TextImporter2.java
@@ -63,6 +63,9 @@ final class TextImporter2 {
 		// get a config object
 		TSDB tsdb = null;
 
+		// disable RebaseBatches while importing 	
+		CachedBatches.setEnableRebaseBatches(false);		
+		
 		if (!argp.has("--noimport")) {
 			Config config = CliOptions.getConfig(argp);
 			argp = null;


### PR DESCRIPTION
(1) Prevent the rebaseBatches timer task from inadvertently rebasing batches during historical data loads.
(2) Add the final metadata value byte to the batch value array to indicate not mixed compact.
(3) Update TextImporter2 points data type to long to get correct metrics
